### PR TITLE
🎸 feat(routing): enable frontend routing in the netlify infra

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -7,3 +7,8 @@
     from = "/api/*"
     to = "/.netlify/functions/:splat"
     status = 200
+
+[[redirects]]
+    from = "/*"
+    to = "/"
+    status = 200


### PR DESCRIPTION
In the config we had to tell netlify what it should do for all routes.
In frontend applications every link should redirect to index.html in order to let react do the routing

Closes #9