### PR TITLE
🎸 feat(dynenv): support authentication on dynamic environment

### DIFF
--- a/src/authentication/dynamicEnvSupport.ts
+++ b/src/authentication/dynamicEnvSupport.ts
@@ -1,0 +1,34 @@
+/*
+ * This module contains logic to support dynamic deployment environments.
+ * They are for example used by netlify to provide previews of pull requests.
+ */
+
+/**
+ * Creates a target url for the authentication redirect.
+ * This redirect should be used to move the token to the proper web page.
+ * It should represent the url of the dynamic environment.
+ */
+export function createRedirectTarget() {
+    return `${window.location.protocol}//${window.location.host}/redirect`;
+}
+
+/**
+ * Redirect to the dynamic environment in case one is targeted.
+ * If the target is the current page then nothing will be done.
+ * This step is required because dynamic environments can't be targeted by oauth2 redirects.
+ * 
+ * @param target the actual target of the authentication response
+ * @param params the url parameters containing the authentication information
+ * @return true when it was in fact a dynamic environment
+ */
+export function redirectIfDynamicEnvironment(target: string, params: URLSearchParams) {
+    const redirectTarget = new URL(target);
+
+    if (window.location.host !== redirectTarget.host) {
+        const newLocation = `${redirectTarget}?${params}`
+        window.location.replace(newLocation);
+        return true;
+    }
+
+    return false;
+}

--- a/src/pages/Redirect.tsx
+++ b/src/pages/Redirect.tsx
@@ -3,8 +3,10 @@ import { init } from '../authentication/SpotifyAuthService';
 
 export function Redirect() {
     useEffect(() => {
-        init(window.location.search);
-        window.location.replace('/');
+        const successful = init(window.location.search);
+        if (successful) {
+            window.location.replace('/');
+        }
     })
 
     return (<div>redirecting ...</div>);


### PR DESCRIPTION
Spotify (OAuth2) needs the redirect urls specified in their auth configuration.
Since netlify uses dynamic deployments to provide previews on pull requests we'd need to add every possible dynamic environment target to this list.
Due to security reasons it is not allowed to provide wildcard targets.
Therefore we let the request redirect to our production site which then checks where the request originates from.
If it is in fact a dynamic environment then we'll redirect to that, otherwise the authentication continues.

Closes #8